### PR TITLE
【优化】补全了docker安装脚本中遗漏的箭头，优化格式

### DIFF
--- a/resource/install_scripts/docker_install_jd.sh
+++ b/resource/install_scripts/docker_install_jd.sh
@@ -127,7 +127,8 @@ Input_PanelPort
 
 # 输入端口号
 Input_NotworkType() {
-    echo -n -e "\n\e[33m请输入docker网络模式\n1) brindge[默认]\n2) host\e[0m"
+    inp "\ndocker网络模式\n1) brindge[默认]\n2) host"
+    echo -n -e "\e[33m输入您的选择->\e[0m"
     read NotworkType
     if [ -z "$NotworkType" ]; then
         NotworkType="bridge"


### PR DESCRIPTION
一个对docker安装脚本（[/resource/install_scripts/docker_install_jd.sh](https://github.com/lan-tianxiang/JS_TOOL/blob/A1/resource/install_scripts/docker_install_jd.sh)）的小优化，之前docker网络模式选择是这样的：
![image](https://user-images.githubusercontent.com/31154238/120611621-f3cea500-c486-11eb-9edc-c4cddf623873.png)
![image](https://user-images.githubusercontent.com/31154238/120611638-f7622c00-c486-11eb-92a7-18263b1afe24.png)

少了一个箭头分隔，第一次使用安装的时候，愣了一下，不知道该不该直接输入。

于是我自己改了一下，效过如下：
![image](https://user-images.githubusercontent.com/31154238/120611952-44460280-c487-11eb-9ddc-82e24b2ad2ef.png)
![image](https://user-images.githubusercontent.com/31154238/120611969-47d98980-c487-11eb-829d-a95c32de184e.png)

只改了这一个小地方，可以放心合并代码。

P.S.作者你这个项目太棒了！之前我也有过类似的弄个面板的想法，但是受限于我对前端一窍不通，所以无从下手。看到你这个，眼前一亮，写的很赞。
目前还正在阅读代码中，如果有机会希望能提供一些我个人小贡献~